### PR TITLE
Remove spinner() to increase shell compatibility

### DIFF
--- a/scripts/globals.sh
+++ b/scripts/globals.sh
@@ -277,22 +277,3 @@ aws_configured() {
     AWS_CONFIGURED=false
   fi
 }
-
-#
-# Spinner.
-#
-spinner() {
-  spin='-\|/'
-
-  pid=$1
-  msg=$2
-
-  i=0
-  while kill -0 $pid 2>/dev/null
-  do
-    i=$(( (i+1) %4 ))
-    printf "\r${msg} ${spin:$i:1} "
-    sleep .1
-  done
-  printf "\r\n"
-}

--- a/scripts/sifnode/kubernetes/aws/status.sh
+++ b/scripts/sifnode/kubernetes/aws/status.sh
@@ -33,7 +33,7 @@ init() {
 
   docker pull sifchain/wizard:latest 2>/dev/null &
   pid=$!
-  spinner $pid "Please wait..."
+  echo $pid "Please wait..."
   clear
 }
 

--- a/scripts/sifnode/kubernetes/wizard.sh
+++ b/scripts/sifnode/kubernetes/wizard.sh
@@ -31,7 +31,7 @@ init() {
 
   docker pull sifchain/wizard:latest 2>/dev/null &
   pid=$!
-  spinner $pid "Installing dependencies. Please wait..."
+  echo $pid "Installing dependencies. Please wait..."
   clear
 }
 

--- a/scripts/sifnode/standalone/wizard.sh
+++ b/scripts/sifnode/standalone/wizard.sh
@@ -29,7 +29,7 @@ init() {
   cat "$(pwd)"/scripts/.logo
   docker pull sifchain/sifnoded:"${CHAIN_ID}" 2>/dev/null &
   pid=$!
-  spinner $pid "Installing dependencies. Please wait..."
+  echo "Installing dependencies. Please wait..."
 }
 
 #


### PR DESCRIPTION
There's probably a more elegant way to handle this but as far as I can tell all the spinner-triggering operations occur much too quickly for it to be of use.

Resolves #32 