### PR TITLE
Update setup.md

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -4,7 +4,7 @@
 
 #### Prerequisites / Dependencies:
 
-- Clone this repository (`git clone ssh://git@github.com/Sifchain/sifchain-validators`)
+- Clone this repository (`git clone https://github.com/Sifchain/sifchain-validators.git`)
 - [Docker](https://www.docker.com/get-started)
 - [jq](https://stedolan.github.io/jq/)
 


### PR DESCRIPTION
You can only ssh clone if the key is saved to the github org. This makes it so anyone may run the command.