### PR TITLE
[ChainOps] Upgrade

### DIFF
--- a/docs/nodes/operations/standalone/manual/upgrades/v0.10.0.md
+++ b/docs/nodes/operations/standalone/manual/upgrades/v0.10.0.md
@@ -1,0 +1,34 @@
+# Upgrades
+
+## v0.10.0
+
+1. Log into your node.
+
+2. Create the new directory for v0.10.0:
+
+```console
+mkdir -p "${HOME}"/.sifnoded/cosmovisor/upgrades/0.10.0/bin
+```
+
+3. Download the upgrade:
+
+```console
+cd "${HOME}"/.sifnoded/cosmovisor/upgrades/0.10.0/bin
+wget -O sifchain.zip https://github.com/Sifchain/sifnode/releases/download/v0.10.0/sifnoded-v0.10.0-linux-amd64.zip
+```
+
+4. Verify the upgrade:
+
+```console
+sha256sum sifchain.zip
+```
+
+and it should equal `56b564f3317234c52f8d4427073f48528362fadf888d2bb2397317d6c70965e7`
+
+5. Unzip:
+
+```console
+unzip sifchain.zip
+```
+
+Once the block height is reached, your node will automatically switch to `v0.10.0`. However, if your node has already halted (you're performing the above steps _after_ the height has already been reached), then simply restart your node once you've completed the above.


### PR DESCRIPTION
Includes:

* Instructions for upgrading to `v0.10.0` of `sifnoded`.