### PR TITLE
[ChainOps] Upgrade documentation

### DIFF
--- a/docs/nodes/operations/standalone/manual/upgrades/v0.13.0.md
+++ b/docs/nodes/operations/standalone/manual/upgrades/v0.13.0.md
@@ -1,0 +1,34 @@
+# Upgrades
+
+## v0.13.0
+
+1. Log into your node.
+
+2. Create the new directory for v0.13.0:
+
+```console
+mkdir -p "${HOME}"/.sifnoded/cosmovisor/upgrades/0.13.0/bin
+```
+
+3. Download the upgrade:
+
+```console
+cd "${HOME}"/.sifnoded/cosmovisor/upgrades/0.13.0/bin
+wget -O sifchain.zip https://github.com/Sifchain/sifnode/releases/download/v0.13.0/sifnoded-v0.13.0-linux-amd64.zip
+```
+
+4. Verify the upgrade:
+
+```console
+sha256sum sifchain.zip
+```
+
+and it should equal `3f9ca8151b2940b8841abf3818a3269938788142dd4b9e02478c998453ce04a9`
+
+5. Unzip:
+
+```console
+unzip sifchain.zip
+```
+
+Once the block height is reached, your node will automatically switch to `v0.13.0`. However, if your node has already halted (you're performing the above steps _after_ the height has already been reached), then simply restart your node once you've completed the above.


### PR DESCRIPTION
Includes:

* Basic documentation for upgrading a standalone node to `v0.13.0`.